### PR TITLE
Add --output_dir to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ To train DeiT-small and Deit-tiny on ImageNet on a single node with 4 gpus for 3
 
 DeiT-small
 ```
-python -m torch.distributed.launch --nproc_per_node=4 --use_env main.py --model deit_small_patch16_224 --batch-size 256 --data-path /path/to/imagenet
+python -m torch.distributed.launch --nproc_per_node=4 --use_env main.py --model deit_small_patch16_224 --batch-size 256 --data-path /path/to/imagenet --output_dir /path/to/save
 ```
 
 DeiT-tiny
 ```
-python -m torch.distributed.launch --nproc_per_node=4 --use_env main.py --model deit_tiny_patch16_224 --batch-size 256 --data-path /path/to/imagenet
+python -m torch.distributed.launch --nproc_per_node=4 --use_env main.py --model deit_tiny_patch16_224 --batch-size 256 --data-path /path/to/imagenet --output_dir /path/to/save
 ```
 
 ### Multinode training


### PR DESCRIPTION
This will make it clearer to users that they need to specify it if running without run_with_submitit, so that the results can be saved