### PR TITLE
Add distilled and finetuned models to MODEL_ZOO

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ We provide baseline DeiT models pretrained on ImageNet 2012.
 | DeiT-tiny | 72.2 | 91.1 | 5M | [model](https://dl.fbaipublicfiles.com/deit/deit_tiny_patch16_224-a1311bcf.pth) |
 | DeiT-small | 79.9 | 95.0 | 22M| [model](https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth) |
 | DeiT-base | 81.8 | 95.6 | 86M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth) |
+| DeiT-tiny distilled | 73.4 | 91.4 | 5M | [model](https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-14f6b9f6.pth) |
+| DeiT-small distilled | 80.9 | 95.3 | 22M| [model](https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-5eda0aa2.pth) |
+| DeiT-base distilled | 83.1 | 96.3 | 86M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-785008a2.pth) |
+| DeiT-base 384 | 82.9 | 96.2 | 86M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_patch16_384-8de9b5d1.pth) |
 
 
 The models are also available via torch hub.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ which should give
 
 ### Distillation
 
-Here you'll find the command-lines to reproduce the inference results for the distilled models
+Here you'll find the command-lines to reproduce the inference results for the distilled and finetuned models
 
 <details>
 
@@ -123,7 +123,7 @@ deit_base_distilled_patch16_224
 </summary>
 
 ```
-python main.py --eval --model deit_base_distilled_patch16_224 --resume checkpoints/deit_base_distilled_patch16_224.pth
+python main.py --eval --model deit_base_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-785008a2.pth
 ```
 giving
 ```
@@ -140,7 +140,7 @@ deit_small_distilled_patch16_224
 </summary>
 
 ```
-python main.py --eval --model deit_small_distilled_patch16_224 --resume checkpoints/deit_small_distilled_patch16_224.pth
+python main.py --eval --model deit_small_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-5eda0aa2.pth
 ```
 giving
 ```
@@ -156,7 +156,7 @@ deit_tiny_distilled_patch16_224
 </summary>
 
 ```
-python main.py --eval --model deit_tiny_distilled_patch16_224 --resume checkpoints/deit_tiny_distilled_patch16_224.pth
+python main.py --eval --model deit_tiny_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-14f6b9f6.pth
 ```
 giving
 ```
@@ -165,15 +165,21 @@ giving
 
 </details>
 
-### Finetune
+<details>
+
+<summary>
+deit_base_patch16_384
+</summary>
 
 ```
-python main.py --resume checkpoints/deit_base_patch16_384-8de9b5d1.pth --model deit_base_patch16_384 --input-size 384 --eval
+python main.py --eval --model deit_base_patch16_384 --input-size 384 --resume https://dl.fbaipublicfiles.com/deit/deit_base_patch16_384-8de9b5d1.pth
 ```
-
+giving
 ```
 * Acc@1 82.890 Acc@5 96.222 loss 0.764
 ```
+
+</details>
 
 ## Training
 To train DeiT-small and Deit-tiny on ImageNet on a single node with 4 gpus for 300 epochs run:

--- a/README.md
+++ b/README.md
@@ -114,29 +114,56 @@ which should give
 
 ### Distillation
 
+Here you'll find the command-lines to reproduce the inference results for the distilled models
+
+<details>
+
+<summary>
+deit_base_distilled_patch16_224
+</summary>
+
 ```
 python main.py --eval --model deit_base_distilled_patch16_224 --resume checkpoints/deit_base_distilled_patch16_224.pth
 ```
-
+giving
 ```
 * Acc@1 83.060 Acc@5 96.296 loss 0.684
 ```
 
+</details>
+
+
+<details>
+
+<summary>
+deit_small_distilled_patch16_224
+</summary>
+
 ```
 python main.py --eval --model deit_small_distilled_patch16_224 --resume checkpoints/deit_small_distilled_patch16_224.pth
 ```
-
+giving
 ```
 * Acc@1 80.880 Acc@5 95.310 loss 0.752
 ```
 
+</details>
+
+<details>
+
+<summary>
+deit_tiny_distilled_patch16_224
+</summary>
+
 ```
 python main.py --eval --model deit_tiny_distilled_patch16_224 --resume checkpoints/deit_tiny_distilled_patch16_224.pth
 ```
-
+giving
 ```
 * Acc@1 73.408 Acc@5 91.368 loss 1.068
 ```
+
+</details>
 
 ### Finetune
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,6 @@ which should give
 * Acc@1 72.202 Acc@5 91.124 loss 1.219
 ```
 
-
-### Distillation
-
 Here you'll find the command-lines to reproduce the inference results for the distilled and finetuned models
 
 <details>
@@ -194,6 +191,7 @@ DeiT-tiny
 python -m torch.distributed.launch --nproc_per_node=4 --use_env main.py --model deit_tiny_patch16_224 --batch-size 256 --data-path /path/to/imagenet --output_dir /path/to/save
 ```
 
+
 ### Multinode training
 
 Distributed training is available via Slurm and [submitit](https://github.com/facebookincubator/submitit):
@@ -206,6 +204,17 @@ To train DeiT-base model on ImageNet on 2 nodes with 8 gpus each for 300 epochs:
 
 ```
 python run_with_submitit.py --model deit_base_patch16_224 --data-path /path/to/imagenet
+```
+
+
+To train DeiT-base with hard distillation using a RegNetY-160 as teacher, on 2 nodes with 8 GPUs with 32GB each for 300 epochs (make sure that the model weights for the teacher have been downloaded before to the correct location, to avoid multiple workers writing to the same file):
+```
+python run_with_submitit.py --model deit_base_distilled_patch16_224 --distillation-type hard --teacher-model regnety_160 --teacher-path https://dl.fbaipublicfiles.com/deit/regnety_160-a5fe301d.pth --use_volta32
+```
+
+To finetune a DeiT-base on 384 resolution images for 30 epochs, starting from a DeiT-base trained on 224 resolution images, do (make sure that the weights to the original model have been downloaded before, to avoid multiple workers writing to the same file):
+```
+ run_with_submitit.py --model deit_base_patch16_384 --batch-size 32 --finetune https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth --input-size 384 --use_volta32 --nodes 2 --lr 5e-6 --weight-decay 1e-8 --epochs 30 --min-lr 5e-6
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -107,6 +107,43 @@ which should give
 * Acc@1 72.202 Acc@5 91.124 loss 1.219
 ```
 
+
+### Distillation
+
+```
+python main.py --eval --model deit_base_distilled_patch16_224 --resume checkpoints/deit_base_distilled_patch16_224.pth
+```
+
+```
+* Acc@1 83.060 Acc@5 96.296 loss 0.684
+```
+
+```
+python main.py --eval --model deit_small_distilled_patch16_224 --resume checkpoints/deit_small_distilled_patch16_224.pth
+```
+
+```
+* Acc@1 80.880 Acc@5 95.310 loss 0.752
+```
+
+```
+python main.py --eval --model deit_tiny_distilled_patch16_224 --resume checkpoints/deit_tiny_distilled_patch16_224.pth
+```
+
+```
+* Acc@1 73.408 Acc@5 91.368 loss 1.068
+```
+
+### Finetune
+
+```
+python main.py --resume checkpoints/deit_base_patch16_384-8de9b5d1.pth --model deit_base_patch16_384 --input-size 384 --eval
+```
+
+```
+* Acc@1 82.890 Acc@5 96.222 loss 0.764
+```
+
 ## Training
 To train DeiT-small and Deit-tiny on ImageNet on a single node with 4 gpus for 300 epochs run:
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ To train DeiT-base model on ImageNet on 2 nodes with 8 gpus each for 300 epochs:
 python run_with_submitit.py --model deit_base_patch16_224 --data-path /path/to/imagenet
 ```
 
-
 To train DeiT-base with hard distillation using a RegNetY-160 as teacher, on 2 nodes with 8 GPUs with 32GB each for 300 epochs (make sure that the model weights for the teacher have been downloaded before to the correct location, to avoid multiple workers writing to the same file):
 ```
 python run_with_submitit.py --model deit_base_distilled_patch16_224 --distillation-type hard --teacher-model regnety_160 --teacher-path https://dl.fbaipublicfiles.com/deit/regnety_160-a5fe301d.pth --use_volta32
@@ -214,7 +213,7 @@ python run_with_submitit.py --model deit_base_distilled_patch16_224 --distillati
 
 To finetune a DeiT-base on 384 resolution images for 30 epochs, starting from a DeiT-base trained on 224 resolution images, do (make sure that the weights to the original model have been downloaded before, to avoid multiple workers writing to the same file):
 ```
- run_with_submitit.py --model deit_base_patch16_384 --batch-size 32 --finetune https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth --input-size 384 --use_volta32 --nodes 2 --lr 5e-6 --weight-decay 1e-8 --epochs 30 --min-lr 5e-6
+python run_with_submitit.py --model deit_base_patch16_384 --batch-size 32 --finetune https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth --input-size 384 --use_volta32 --nodes 2 --lr 5e-6 --weight-decay 1e-8 --epochs 30 --min-lr 5e-6
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ We provide baseline DeiT models pretrained on ImageNet 2012.
 | --- | --- | --- | --- | --- |
 | DeiT-tiny | 72.2 | 91.1 | 5M | [model](https://dl.fbaipublicfiles.com/deit/deit_tiny_patch16_224-a1311bcf.pth) |
 | DeiT-small | 79.9 | 95.0 | 22M| [model](https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth) |
-| DeiT-base | 81.8 | 95.6 | 86M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth) |
-| DeiT-tiny distilled | 73.4 | 91.4 | 5M | [model](https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-14f6b9f6.pth) |
-| DeiT-small distilled | 80.9 | 95.3 | 22M| [model](https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-5eda0aa2.pth) |
-| DeiT-base distilled | 83.1 | 96.3 | 86M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-785008a2.pth) |
-| DeiT-base 384 | 82.9 | 96.2 | 86M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_patch16_384-8de9b5d1.pth) |
+| DeiT-base | 81.8 | 95.6 | 86M | model](https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth) |
+| DeiT-tiny distilled | 74.5 | 91.9 | 6M | [model](https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-b40b3cf7.pth) |
+| DeiT-small distilled | 81.2 | 95.4 | 22M| [model](https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-649709d9.pth) |
+| DeiT-base distilled | 83.4 | 96.5 | 87M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-df68dfff.pth) |
+| DeiT-base 384 | 82.9 | 96.2 | 87M | [model](https://dl.fbaipublicfiles.com/deit/deit_base_patch16_384-8de9b5d1.pth) |
 
 
 The models are also available via torch hub.
@@ -120,11 +120,11 @@ deit_base_distilled_patch16_224
 </summary>
 
 ```
-python main.py --eval --model deit_base_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-785008a2.pth
+python main.py --eval --model deit_base_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-df68dfff.pth
 ```
 giving
 ```
-* Acc@1 83.060 Acc@5 96.296 loss 0.684
+* Acc@1 83.372 Acc@5 96.482 loss 0.685
 ```
 
 </details>
@@ -137,11 +137,11 @@ deit_small_distilled_patch16_224
 </summary>
 
 ```
-python main.py --eval --model deit_small_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-5eda0aa2.pth
+python main.py --eval --model deit_small_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-649709d9.pth
 ```
 giving
 ```
-* Acc@1 80.880 Acc@5 95.310 loss 0.752
+* Acc@1 81.164 Acc@5 95.376 loss 0.752
 ```
 
 </details>
@@ -153,11 +153,11 @@ deit_tiny_distilled_patch16_224
 </summary>
 
 ```
-python main.py --eval --model deit_tiny_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-14f6b9f6.pth
+python main.py --eval --model deit_tiny_distilled_patch16_224 --resume https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-b40b3cf7.pth
 ```
 giving
 ```
-* Acc@1 73.408 Acc@5 91.368 loss 1.068
+* Acc@1 74.476 Acc@5 91.920 loss 1.021
 ```
 
 </details>

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.
-from models import deit_tiny_patch16_224, deit_small_patch16_224, deit_base_patch16_224
+from models import *
 
 dependencies = ["torch", "torchvision", "timm"]

--- a/models.py
+++ b/models.py
@@ -111,7 +111,7 @@ def deit_tiny_distilled_patch16_224(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-14f6b9f6.pth",
+            url="https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-b40b3cf7.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])
@@ -126,7 +126,7 @@ def deit_small_distilled_patch16_224(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-5eda0aa2.pth",
+            url="https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-649709d9.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])
@@ -141,7 +141,7 @@ def deit_base_distilled_patch16_224(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-785008a2.pth",
+            url="https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-df68dfff.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])

--- a/models.py
+++ b/models.py
@@ -9,6 +9,13 @@ from timm.models.registry import register_model
 from timm.models.layers import trunc_normal_
 
 
+__all__ = [
+    'deit_tiny_patch16_224', 'deit_small_patch16_224', 'deit_base_patch16_224',
+    'deit_tiny_distilled_patch16_224', 'deit_small_distilled_patch16_224',
+    'deit_base_distilled_patch16_224', 'deit_base_patch16_384'
+]
+
+
 class DistilledVisionTransformer(VisionTransformer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/models.py
+++ b/models.py
@@ -104,7 +104,7 @@ def deit_tiny_distilled_patch16_224(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="",
+            url="https://dl.fbaipublicfiles.com/deit/deit_tiny_distilled_patch16_224-14f6b9f6.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])
@@ -119,7 +119,7 @@ def deit_small_distilled_patch16_224(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="",
+            url="https://dl.fbaipublicfiles.com/deit/deit_small_distilled_patch16_224-5eda0aa2.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])
@@ -134,7 +134,7 @@ def deit_base_distilled_patch16_224(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="",
+            url="https://dl.fbaipublicfiles.com/deit/deit_base_distilled_patch16_224-785008a2.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])
@@ -149,7 +149,7 @@ def deit_base_patch16_384(pretrained=False, **kwargs):
     model.default_cfg = _cfg()
     if pretrained:
         checkpoint = torch.hub.load_state_dict_from_url(
-            url="",
+            url="https://dl.fbaipublicfiles.com/deit/deit_base_patch16_384-8de9b5d1.pth",
             map_location="cpu", check_hash=True
         )
         model.load_state_dict(checkpoint["model"])


### PR DESCRIPTION
This PR adds pre-trained weights with corresponding command-line arguments to obtain the fine-tuned and the distilled models, and torchhub compatibilty.

For the distilled models, we also uploaded a pre-trained RegNetY-160, which is used as a teacher for the other models.