### PR TITLE
Delete Unused Args dpr_constant In cait_S36

### DIFF
--- a/cait_models.py
+++ b/cait_models.py
@@ -327,7 +327,6 @@ def cait_S36(pretrained=False, **kwargs):
     model = cait_models(
         img_size= 384,patch_size=16, embed_dim=384, depth=36, num_heads=8, mlp_ratio=4, qkv_bias=True,
         norm_layer=partial(nn.LayerNorm, eps=1e-6),
-        dpr_constant=True,
         init_scale=1e-6,
         depth_token_only=2,**kwargs)
     


### PR DESCRIPTION
which will cause a TypeError when init cait_models()

```python
---------------------------------------------------------------------------
TypeError   Traceback (most recent call last)
<***> in <module>
     56 ***
     57 ***
---> 58 model = cait_S36(pretrained=False, num_classes=2)
     59 ***
     60 ***

/***/deit/cait_models.py in cait_S36(pretrained, **kwargs)
    325 @register_model
    326 def cait_S36(pretrained=False, **kwargs):
--> 327     model = cait_models(
    328         img_size= 384,patch_size=16, embed_dim=384, depth=36, num_heads=8, mlp_ratio=4, qkv_bias=True,
    329         norm_layer=partial(nn.LayerNorm, eps=1e-6),

TypeError: __init__() got an unexpected keyword argument 'dpr_constant'
```