### PR TITLE
BUG Fix: ensure the right loss function is selected when mixtup or cu…

### DIFF
--- a/main.py
+++ b/main.py
@@ -310,7 +310,7 @@ def main(args):
 
     criterion = LabelSmoothingCrossEntropy()
 
-    if args.mixup > 0.:
+    if mixup_active > 0.:
         # smoothing is handled with mixup label transform
         criterion = SoftTargetCrossEntropy()
     elif args.smoothing:

--- a/main.py
+++ b/main.py
@@ -310,7 +310,7 @@ def main(args):
 
     criterion = LabelSmoothingCrossEntropy()
 
-    if mixup_active > 0.:
+    if mixup_active:
         # smoothing is handled with mixup label transform
         criterion = SoftTargetCrossEntropy()
     elif args.smoothing:


### PR DESCRIPTION
…tmix is enabeled

When mixup is disabled but cutmix is enabled, CrossEntropyLoss is instantiated but SoftTargetCrossEntropy is needed. 