### PR TITLE
Use torch.repeat_interleave() to generate the repeated indices faster

### DIFF
--- a/samplers.py
+++ b/samplers.py
@@ -13,7 +13,7 @@ class RASampler(torch.utils.data.Sampler):
     Heavily based on torch.utils.data.DistributedSampler
     """
 
-    def __init__(self, dataset, num_replicas=None, rank=None, shuffle=True):
+    def __init__(self, dataset, num_replicas=None, rank=None, shuffle=True, num_repeats: int = 3):
         if num_replicas is None:
             if not dist.is_available():
                 raise RuntimeError("Requires distributed package to be available")
@@ -25,8 +25,9 @@ class RASampler(torch.utils.data.Sampler):
         self.dataset = dataset
         self.num_replicas = num_replicas
         self.rank = rank
+        self.num_repeats = num_repeats
         self.epoch = 0
-        self.num_samples = int(math.ceil(len(self.dataset) * 3.0 / self.num_replicas))
+        self.num_samples = int(math.ceil(len(self.dataset) * self.num_repeats / self.num_replicas))
         self.total_size = self.num_samples * self.num_replicas
         # self.num_selected_samples = int(math.ceil(len(self.dataset) / self.num_replicas))
         self.num_selected_samples = int(math.floor(len(self.dataset) // 256 * 256 / self.num_replicas))
@@ -36,13 +37,13 @@ class RASampler(torch.utils.data.Sampler):
         if self.shuffle:
             # deterministically shuffle based on epoch
             g = torch.Generator()
-            g.manual_seed(self.epoch)            
-            indices = torch.randperm(len(self.dataset), generator=g).tolist()
+            g.manual_seed(self.epoch)
+            indices = torch.randperm(len(self.dataset), generator=g)
         else:
-            indices = list(range(len(self.dataset)))
+            indices = torch.arange(start=0, end=len(self.dataset))
 
         # add extra samples to make it evenly divisible
-        indices = [ele for ele in indices for i in range(3)]
+        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0).tolist()
         indices += indices[:(self.total_size - len(indices))]
         assert len(indices) == self.total_size
 

--- a/samplers.py
+++ b/samplers.py
@@ -22,6 +22,8 @@ class RASampler(torch.utils.data.Sampler):
             if not dist.is_available():
                 raise RuntimeError("Requires distributed package to be available")
             rank = dist.get_rank()
+        if num_repeats < 1:
+            raise ValueError("num_repeats should be greater than 0")
         self.dataset = dataset
         self.num_replicas = num_replicas
         self.rank = rank

--- a/samplers.py
+++ b/samplers.py
@@ -48,7 +48,7 @@ class RASampler(torch.utils.data.Sampler):
         indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0)
         padding_size: int = self.total_size - len(indices)
         if padding_size > 0:
-            indices += torch.cat([indices, indices[:padding_size]], dim=0)
+            indices = torch.cat([indices, indices[:padding_size]], dim=0)
         assert len(indices) == self.total_size
 
         # subsample

--- a/samplers.py
+++ b/samplers.py
@@ -45,8 +45,10 @@ class RASampler(torch.utils.data.Sampler):
             indices = torch.arange(start=0, end=len(self.dataset))
 
         # add extra samples to make it evenly divisible
-        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0).tolist()
-        indices += indices[:(self.total_size - len(indices))]
+        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0)
+        padding_size: int = self.total_size - len(indices)
+        if padding_size > 0:
+            indices += torch.cat([indices, indices[:padding_size]], dim=0)
         assert len(indices) == self.total_size
 
         # subsample


### PR DESCRIPTION
## Change Log

* Use `torch.repeat_interleave()` to generate the repeated indices faster
* Add `num_repeats` parameter to `RASampler` (default: 3)

## Performance Benchmark

* Python 3.7
* OS : Windows 10
* CPU : i7-7700K (not overclocked)

<details>
<summary>code</summary>

```
from time import time
import numpy as np
import torch


def get_indices_v1(x, num_repeats: int = 3):
    return [i for i in x for _ in range(num_repeats)]


def get_indices_v2(x, num_repeats: int = 3):
    return np.repeat(x, repeats=num_repeats, axis=0).tolist()


def get_indices_v3(x, num_repeats: int = 3):
    return torch.repeat_interleave(x, repeats=num_repeats, dim=0).tolist()


if __name__ == '__main__':
    for num_datasets in (int(1e5), int(1e6), int(1e7)):
        indices: torch.Tensor = torch.arange(start=0, end=num_datasets)

        v1, v2, v3 = [], [], []
        for _ in range(10):
            start_time = time()
            _ = get_indices_v1(indices.tolist())
            end_time = time()
            v1.append(end_time - start_time)

            start_time = time()
            _ = get_indices_v2(indices.tolist())
            end_time = time()
            v2.append(end_time - start_time)

            start_time = time()
            _ = get_indices_v3(indices)
            end_time = time()
            v3.append(end_time - start_time)

        print(f'num_datasets {num_datasets}')
        print(f'list comprehension      : {np.mean(v1):.6f}s')
        print(f'np.repeat               : {np.mean(v2):.6f}s')
        print(f'torch.repeat_interleave : {np.mean(v3):.6f}s')
        print()

```

</details>

```
num_datasets 100000
list comprehension      : 0.031251s
np.repeat               : 0.015623s
torch.repeat_interleave : 0.009376s

num_datasets 1000000
list comprehension      : 0.292203s
np.repeat               : 0.132806s
torch.repeat_interleave : 0.129676s

num_datasets 10000000
list comprehension      : 2.788492s
np.repeat               : 1.306345s
torch.repeat_interleave : 1.042842s
```