### PR TITLE
fixed typo in path for 2nd validation class

### DIFF
--- a/README_deit.md
+++ b/README_deit.md
@@ -91,7 +91,7 @@ The directory structure is the standard layout for the torchvision [`datasets.Im
   val/
     class1/
       img3.jpeg
-    class/2
+    class2/
       img4.jpeg
 ```
 


### PR DESCRIPTION
The path for the 2nd validation class was incorrect. The dash has to be after the '2'.