### PR TITLE
Fix img_size for DeiT-III

### DIFF
--- a/main.py
+++ b/main.py
@@ -258,6 +258,7 @@ def main(args):
         drop_rate=args.drop,
         drop_path_rate=args.drop_path,
         drop_block_rate=None,
+        img_size=args.input_size
     )
 
                     


### PR DESCRIPTION
Allows for pretraining at different input size. Otherwise it raises `AssertionError: Input image size (192*192) doesn't match model (224*224).`