### PR TITLE
Fix error "TypeError: type object got multiple values for keyword argument"

### DIFF
--- a/models.py
+++ b/models.py
@@ -152,7 +152,7 @@ def deit_base_distilled_patch16_224(pretrained=False, **kwargs):
 @register_model
 def deit_base_patch16_384(pretrained=False, **kwargs):
     model = VisionTransformer(
-        img_size=384, patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
         norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     model.default_cfg = _cfg()
     if pretrained:
@@ -167,7 +167,7 @@ def deit_base_patch16_384(pretrained=False, **kwargs):
 @register_model
 def deit_base_distilled_patch16_384(pretrained=False, **kwargs):
     model = DistilledVisionTransformer(
-        img_size=384, patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
         norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     model.default_cfg = _cfg()
     if pretrained:


### PR DESCRIPTION
When I tried to use the model "deit_base_distilled_patch16_384" or "deit_base_patch16_384" I got this error: "TypeError: type object got multiple values for keyword argument" so I delete the img_size variable of these models and I added the arg "input-size" when I train the model, look this example:
`python main.py --model deit_base_distilled_patch16_384 --input-size 384 --batch-size 16 --epochs 100 --output_dir /content/deit/output --data-path /content/dataset`
