### PR TITLE
Fix Spelling Error: Correct "defaul" to "default"

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,7 +181,7 @@ def get_args_parser():
     parser.set_defaults(pin_mem=True)
 
     # distributed training parameters
-    parser.add_argument('--distributed', action='store_true', defaul=False, help='Enabling distributed training')
+    parser.add_argument('--distributed', action='store_true', default=False, help='Enabling distributed training')
     parser.add_argument('--world_size', default=1, type=int,
                         help='number of distributed processes')
     parser.add_argument('--dist_url', default='env://', help='url used to set up distributed training')


### PR DESCRIPTION
Hi,

I noticed a spelling error in this  repository where "default" is misspelled as "defaul". 

I modified the file main.py and corrected "defaul" to "default" on line 184.

I would appreciate it if you could merge this fix into the main branch to maintain code accuracy and consistency. Thank you!